### PR TITLE
Fix MPI demo

### DIFF
--- a/MPI/tests/test_halo.pf
+++ b/MPI/tests/test_halo.pf
@@ -103,13 +103,13 @@ contains
       real :: array(NX_LOC,0:NY_LOC+1)
 
       ! Preconditions
+      rank = this%getProcessRank()
       array(1:NX_LOC,0) = HALO_UNDEF
       array(1:NX_LOC,NY_LOC + 1) = HALO_UNDEF
       array(1:NX_LOC,1:NY_LOC) = rank
 
       call fill_halo(array, this%getMpiCommunicator())
 
-      rank = this%getProcessRank()
       if (rank > 0) then ! southern halo
          @assertEqual(rank - 1, array(1:NX_LOC,0)) 
       end if

--- a/MPI/tests/test_halo.pf
+++ b/MPI/tests/test_halo.pf
@@ -54,7 +54,7 @@ contains
    !--------------
    @test(npes=[1,2,3,4])
    subroutine test_fill_halo_interior(this)
-      type (MpiTestMethod), intent(inout) :: this
+      class (MpiTestMethod), intent(inout) :: this
       real :: array(NX_LOC,0:NY_LOC+1) ! local domain with halo region
       real :: interior_value
 
@@ -75,7 +75,7 @@ contains
 
    @test(npes=[1,2,3])
    subroutine test_fill_halo_south_pole(this)
-      type (MpiTestMethod) :: this
+      class (MpiTestMethod), intent(inout) :: this
 
       integer :: rank
       real :: array(NX_LOC,0:NY_LOC+1)
@@ -97,7 +97,7 @@ contains
 
    @test(npes=[1,2,3])
    subroutine test_fill_halo_south_other(this)
-      type (MpiTestMethod) :: this
+      class (MpiTestMethod), intent(inout) :: this
 
       integer :: rank
       real :: array(NX_LOC,0:NY_LOC+1)
@@ -118,7 +118,7 @@ contains
 
    @test(npes=[1,2,3])
    subroutine test_fill_halo_north_pole(this)
-      type (MpiTestMethod) :: this
+      class (MpiTestMethod), intent(inout) :: this
 
       integer :: rank, npes
 
@@ -144,7 +144,7 @@ contains
 
    @test(npes=[1,2,3])
    subroutine test_fill_halo_north_other(this)
-      type (MpiTestMethod) :: this
+      class (MpiTestMethod), intent(inout) :: this
 
       integer :: rank, npes
       real :: array(NX_LOC,0:NY_LOC+1)


### PR DESCRIPTION
Gfortran 8.3 still fails due to `free(): invalid pointer` on exit (although all the tests pass). I have a valgrind trace if that would be useful? Seems to be coming from the copy of `MpiTestMethod` via `load_tests`.