### PR TITLE
Updates related to #124

### DIFF
--- a/Basic/.gitignore
+++ b/Basic/.gitignore
@@ -1,1 +1,2 @@
 /build
+/tap

--- a/MPI/Makefile
+++ b/MPI/Makefile
@@ -1,0 +1,22 @@
+ifeq (nagfor,$(findstring nagfor,$(FC)))
+  FFLAGS += -fpp
+endif
+export FFLAGS
+
+include $(PFUNIT_DIR)/PFUNIT-4.0/include/PFUNIT.mk
+
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS)
+
+all:
+	$(MAKE) -C src all
+	$(MAKE) -C tests all
+
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+
+
+clean:
+	$(MAKE) -C src clean
+	$(MAKE) -C tests clean

--- a/MPI/build_with_make_and_run.x
+++ b/MPI/build_with_make_and_run.x
@@ -1,0 +1,12 @@
+#!/bin/bash -f
+
+if [[ -d build ]]
+then
+    rm -rf build
+fi
+
+make all
+
+mpirun -np 4 ./tests/test_halo
+
+

--- a/MPI/src/Makefile
+++ b/MPI/src/Makefile
@@ -1,0 +1,14 @@
+SRCS := halo.F90
+OBJS := $(SRCS:%.F90=%.o)
+
+all: libsut.a
+
+libsut.a: $(OBJS)
+	$(AR) -r $@ $?
+
+%.o : %.F90
+	$(MPIF90) -c $(FFLAGS) $<
+
+clean:
+	$(RM) *.o *.mod *.a
+

--- a/MPI/tests/Makefile
+++ b/MPI/tests/Makefile
@@ -1,0 +1,20 @@
+USEMPI=YES
+include $(PFUNIT_DIR)/PFUNIT-4.0/include/PFUNIT.mk
+
+all: test_halo
+
+FFLAGS += $(PFUNIT_EXTRA_FFLAGS)
+FFLAGS += -I../src
+
+%.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+test_halo_TESTS := test_halo.pf
+test_halo_OTHER_LIBRARIES := -L../src -lsut
+$(eval $(call make_pfunit_test,test_halo))
+
+
+clean:
+	$(RM) *.o *.mod *.a  *.inc
+	$(RM) test_halo.F90
+

--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ This repository contains a sequence of small self-contained examples
 that demonstrate how to use pFUnit.  Most are intended to be built
 with cmake and all assume that you already have installed pFUnit.
 
-Generally within each directory, one can build and execute the demo
-by executing either
+
+First, set PFUNIT_DIR environment variable to the path where pFUnit
+was installed.
+
+
+Then, within each directory, one can build and execute the demo by
+executing either
 
 	./build_with_cmake_and_run.x
 
@@ -41,18 +46,21 @@ from the command line.
       capabilities.
 
 
-### Parameterized
-
-      This demo is relies on some advanced pFUnit capabilities to
-      demonstrate somewhat realistic parameterized test cases.
-      
-
 ### MPI
 
       This demo uses pFUnit's parallel capabilities and includes some
       advanced cases with fixtures and parameterized tests.
 
-### fHamcrest
+
+
+
+### Parameterized  (unimplemented)
+
+      This demo is relies on some advanced pFUnit capabilities to
+      demonstrate somewhat realistic parameterized test cases.
+      
+
+### fHamcrest (unimplemented)
 
       New and exciting way to write assertions.  More extensible and
       provides better error messages for complex combinations.


### PR DESCRIPTION
Related to Goddard-Fortran-Ecosystem/pFUnit#24


PFUNIT.mk did not include extra incs and libs needed when building
with MPI.  Have added demonstration Makefile's in the MPI directory,
to exercise the improved support.