### PR TITLE
Automatically set FC to mpifort if FC is not set

### DIFF
--- a/MPI/build_with_make_and_run.x
+++ b/MPI/build_with_make_and_run.x
@@ -2,7 +2,11 @@
 
 make clean
 
-make all
+if [[ ! $FC || -z $FC || $FC == " " ]]; then
+    FC=mpifort make all
+else
+    make all
+fi
 
 mpirun -np 4 ./tests/test_halo
 


### PR DESCRIPTION
It might be good to set the default `FC` environment variable to `mpifort` when none has been specified. Otherwise, `make` will fail because it doesn't know where `mpi.mod` is located. I assume if `FC` is unset then on most cases the system defaults to an MPI-unaware Fortran compiler (e.g. `gfortran` or `ifort`).