### PR TITLE
Add example using pFUnit as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Submodule/external/pFUnit"]
+	path = Submodule/external/pFUnit
+	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ from the command line.
       This demo uses pFUnit's parallel capabilities and includes some
       advanced cases with fixtures and parameterized tests.
 
+### Submodule
 
+      This demo includes pFUnit as a git submodule and builds the test suite
+      using `add_subdirectory` instead of `find_package`, such that `pFUnit`,
+      the demo library and the test suite are built from a single `CMakeLists.txt`
 
 
 ### Parameterized  (unimplemented)

--- a/Submodule/.gitignore
+++ b/Submodule/.gitignore
@@ -1,0 +1,2 @@
+build/
+test/*.F90

--- a/Submodule/CMakeLists.txt
+++ b/Submodule/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.2)
+project(playground LANGUAGES Fortran)
+
+# We want to build the library and test suite with these flags, but do not want these flags to be used for pFUnit.
+set(mylib_fortran_flags "-cpp -fPIC -fdefault-real-8 -fdefault-double-8 -frecursive -Wno-unused-function -Wno-unused-variable")
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/src stufflib)
+add_subdirectory(${CMAKE_SOURCE_DIR}/external/pFUnit)
+add_subdirectory(${CMAKE_SOURCE_DIR}/test)

--- a/Submodule/README.md
+++ b/Submodule/README.md
@@ -1,0 +1,20 @@
+# Example project using `pFUnit` with `add_submodule`
+
+To build and run tests, execute the shell script `build_and_run_tests.sh`.
+
+This is a minimal example of a project where we have some library, built from the files in `src/`, a test suite built from the files in `test/`, and would like to include `pFUnit` in
+our project as a git submodule. Note that the `.gitmodules` file is located in the repository root (`..`). We want to build our library and tests with some set of flags/settings that should
+not effect the building of `pFUnit`.
+
+Building the project defined in `CMakeLists.txt` will compile the library, `pFUnit`, and the tests, such that this example should work also if you don't have an installed version of `pFUnit`.
+
+Note: If you have installed `pFUnit`, and have defined the environment variable `PFUNIT_DIR`, you should `unset PFUNIT_DIR` before building the example, otherwise `cmake` seems to get confused.
+
+The build system has been tested to work using
+  * MacOS 12.5.1
+  * gfortran 13.2.0 (Homebrew)
+  * gcc 13.2.0 (Homebrew)
+  * g++ 13.2.0 (Homebrew)
+  * cmake 3.24.2
+  * make 3.81
+  * pFUnit 4.10

--- a/Submodule/build_and_run_tests.sh
+++ b/Submodule/build_and_run_tests.sh
@@ -1,0 +1,9 @@
+$!/bin/bash
+set -e
+[ -d build ] && rm -r build
+
+mkdir build
+cd build
+cmake ..
+make mytests
+./test/mytests

--- a/Submodule/src/CMakeLists.txt
+++ b/Submodule/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(stufflib LANGUAGES Fortran)
+
+set(CMAKE_Fortran_FLAGS ${mylib_fortran_flags})
+add_library(stuff ${CMAKE_CURRENT_SOURCE_DIR}/stuff.f90)

--- a/Submodule/src/stuff.f90
+++ b/Submodule/src/stuff.f90
@@ -1,0 +1,15 @@
+module stuff
+implicit none
+public :: add
+
+contains
+
+subroutine add(a, b, res)
+    real, intent(in) :: a
+    real, intent(in) :: b
+    real, intent(out) :: res
+
+    res = a + b
+end subroutine add
+
+end module stuff

--- a/Submodule/test/CMakeLists.txt
+++ b/Submodule/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_policy(SET CMP0074 NEW)
+
+set(CMAKE_Fortran_FLAGS ${mylib_fortran_flags})
+
+enable_testing()
+file(GLOB UNITTEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.pf)
+add_pfunit_ctest(mytests TEST_SOURCES ${UNITTEST_SRC} LINK_LIBRARIES stuff)
+target_include_directories(mytests PRIVATE ${CMAKE_BINARY_DIR}/stufflib ${CMAKE_CURRENT_BINARY_DIR})

--- a/Submodule/test/test_stuff.pf
+++ b/Submodule/test/test_stuff.pf
@@ -1,0 +1,19 @@
+module test_stuff
+use funit
+implicit none
+real, parameter :: tol = 1e-10
+contains
+
+@Test
+subroutine test_add()
+    use stuff, only: add
+
+    real :: a = 5.0
+    real :: b = 6.0
+    real :: res
+    
+    call add(a, b, res)
+    @assertEqual(res, a + b, tol)
+end subroutine test_add
+
+end module test_stuff


### PR DESCRIPTION
Adding the minimal example mentioned in #15. Note that the way this is set up, `cmake` seems to get confused if `PFUNIT_DIR` is set (as I guess it usually is if you have an installation of `pFUnit`), so you need to `unset PFUNIT_DIR` to get it to build. Theres probably a more robust way to handle that in the `CMakeLists.txt` (perhaps in `pFUnit` itself?).